### PR TITLE
Set dimension and measure title to "description"

### DIFF
--- a/index.html
+++ b/index.html
@@ -108,7 +108,7 @@
         <% if (dimension.name != 'Measures') { %>
             <li class='parent_dimension'>
                 <span class="root collapsed sprite"></span>
-                    <a class="folder_collapsed sprite" href="#"><%= dimension.name %></a>
+                <a class="folder_collapsed sprite" href="#" title="<%= dimension.description ? dimension.description : '' %>"><%= dimension.name %></a>
                 
                 <ul>
                 <% _.each(dimension.hierarchies, function(hierarchy) { %>
@@ -137,7 +137,7 @@
                 
                 <ul>
                 <% _.each(measures, function(measure) { %>
-                    <li><a title="[Measures].[<%= measure.name %>]" 
+                    <li><a title="[<%= measure.description ? measure.description : measure.uniqueName %>]"
                         class="measure" href="#Measures/member/<%= measure.uniqueName %>"><%= measure.name %></a>
                     </li>
                 <% }); %>


### PR DESCRIPTION
If a description is set for a dimension or measure, set it as the title
so it is visible upon mouse-over.
