### PR TITLE
Clarify proxy arguments in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,9 +23,10 @@ Run UI on Node.js proxy
 ------------------
 You can simply test and run the UI on a node.js proxy server called server.js, that will utilize a remote backend as source.
 
-Just run the following command in your command line and then access the UI in the browser (by default, it will run at http://localhost:8080):
+Just run the following command in your command line and then access the UI in
+the browser (by default, it will run at http://localhost:8080 and proxy requests to dev.analytical-labs.com:80):
 
-    node server.js [port] [backend_url]
+    node server.js [port] [backend_host] [backend_port]
 
 
 Attention: For running the server you will need to install express.

--- a/server.js
+++ b/server.js
@@ -7,19 +7,19 @@
  * To play with the chaos monkey, set the CHAOS_MONKEY environment variable
  * to anything (Preferably a nice name for your chaos monkey).
  * 
- * To start the server, run `node server.js port [url]`
+ * To start the server, run `node server.js [port] [backend_host] [backend_port]`
  */
 
 var http = require('http');
 var express = require('express');
 var app = express.createServer();
 var port = process.env.C9_PORT || parseInt(process.ARGV[2], 10) || 8080;
-var url = process.ARGV[3] || 'dev.analytical-labs.com';
-var remote_port = process.ARGV[4] || 80;
-var proxy = http.createClient(remote_port, url);
+var backend_host = process.ARGV[3] || 'dev.analytical-labs.com';
+var backend_port = process.ARGV[4] || 80;
+var proxy = http.createClient(backend_port, backend_host);
 
 proxy.on('error', function() {
-    proxy = http.createClient(remote_port, url);
+    proxy = http.createClient(backend_port, backend_host);
 });
 
 // Load static server


### PR DESCRIPTION
Make it clear that server.js takes a hostname and port for the backend
server rather than a URL.
