### PR TITLE
Remove extra brackets from measure title

### DIFF
--- a/index.html
+++ b/index.html
@@ -137,7 +137,7 @@
                 
                 <ul>
                 <% _.each(measures, function(measure) { %>
-                    <li><a title="[<%= measure.description ? measure.description : measure.uniqueName %>]"
+                    <li><a title="<%= measure.description ? measure.description : measure.uniqueName %>"
                         class="measure" href="#Measures/member/<%= measure.uniqueName %>"><%= measure.name %></a>
                     </li>
                 <% }); %>


### PR DESCRIPTION
I left an extra pair of brackets around the measure title attribute in 1d99298.
