### PR TITLE
Changed to github

### DIFF
--- a/js/saiku/views/Toolbar.js
+++ b/js/saiku/views/Toolbar.js
@@ -105,7 +105,7 @@ var Toolbar = Backbone.View.extend({
      * Go to the issue tracker
      */
     issue_tracker: function() {
-        window.open('http://projects.analytical-labs.com/projects/saiku/issues/new');
+        window.open('https://github.com/OSBI/saiku-ui/issues/new');
         return false;
     }
 });


### PR DESCRIPTION
I think the tracker is deprecated - here's a new pointer to Github
