### PR TITLE
Members with ' in their nave was making Saiku crash.

### DIFF
--- a/js/saiku/views/SelectionsModal.js
+++ b/js/saiku/views/SelectionsModal.js
@@ -101,7 +101,7 @@ var SelectionsModal = Modal.extend({
                 var member = this.selected_members[j];
                 if (member.levelUniqueName == this.member.level &&
                     member.type == "MEMBER") {
-                    selected_members_opts += "<option value='" + member.uniqueName + "'>" + member.caption + "</option>";
+                    selected_members_opts += "<option value='" + escape(member.uniqueName) + "'>" + member.caption + "</option>";
                     used_members.push(member.caption);
                 }
             }
@@ -118,7 +118,7 @@ var SelectionsModal = Modal.extend({
             var available_members_opts = "";
             for (var i = 0; i < this.available_members.length; i++) {
                 var member = this.available_members[i];
-                available_members_opts += "<option value='" + member.uniqueName + "'>" + member.caption + "</option>";
+                available_members_opts += "<option value='" + escape(member.uniqueName) + "'>" + member.caption + "</option>";
             }
             if (this.available_members.length > 0) {
                 $(available_members_opts).appendTo($(this.el).find('.available_selections select'));
@@ -187,7 +187,7 @@ var SelectionsModal = Modal.extend({
             $(this.el).find('.used_selections option')
                 .each(function(i, selection) {
                 var value = show_u ? 
-                    $(selection).text() : $(selection).val();
+                    $(selection).text() : unescape($(selection).val());
                 updates.push({
                     uniquename: value,
                     type: 'member',


### PR DESCRIPTION
When a member has a caption with an ' in it Saiku was not behaving normally. On the back-end it fires an exception.

With the BI-Plugin on a normal installation of Pentaho with the sampledata :
- Select the SteelWheelsSales
  In Columns : Drag [Measures].[Quantity]
  In Rows : Drag in this order, Line, Vendor, Product.
- Filter Line with Trains
- Filter Product with 1950's Chicago Surface Lines Streetcar

Output should be messed up.

What happens is that saiku-ui send this selection to Saiku backend :

```
[{"hierarchy":"[Product]","uniquename":"[Product].[Product]","type":"level","action":"delete"},{"uniquename":"[Product].[Trains].[Gearbox Collectibles].[1950","type":"member","action":"add"}]
```

The uniqueMemberName becomes inacurrate

```
[Product].[Trains].[Gearbox Collectibles].[1950
```

The patch just escape/unescape the uniqueMemberName so it can go through accurately
