### PR TITLE
Fixing save dialog to be more helpful and not let user save "lost" files

### DIFF
--- a/index.html
+++ b/index.html
@@ -481,7 +481,7 @@
         <script type="text/x-jquery-tmpl" id="template-repository-file">
             <li class='query'>
                 <span class='icon'></span>
-                <a href="#<%= entry.path %>"><%= entry.name %></a>
+                <a href="#<%= entry.path + '/' + entry.name + '.' + entry.fileType %>"><%= entry.name %></a>
             </li>
         </script>
 

--- a/index.html
+++ b/index.html
@@ -481,7 +481,12 @@
         <script type="text/x-jquery-tmpl" id="template-repository-file">
             <li class='query'>
                 <span class='icon'></span>
-                <a href="#<%= entry.path + '/' + entry.name + '.' + entry.fileType %>"><%= entry.name %></a>
+                <% if (entry.path.substring(entry.path.lastIndexOf('/') + 1) !== entry.name + '.' + entry.fileType) { %>
+                <a href="#<%= entry.path + '/' + entry.name + '.' + entry.fileType %>">
+                <% } else { %>
+                <a href="#<%= entry.path %>">
+                <% } %>
+                <%= entry.name %></a>
             </li>
         </script>
 

--- a/js/saiku/views/SaveQuery.js
+++ b/js/saiku/views/SaveQuery.js
@@ -236,6 +236,8 @@ var SaveQuery = Modal.extend({
                     alert(textStatus.responseText);
                 } else {
                     self.close();
+                    alert("Failed to save; server error.  "
+                            + "Perhaps you don't have permissions?");
                 }
                 return true;
         };


### PR DESCRIPTION
I put this commit in a different branch / pull request because I'm not sure how Saiku's behavior differs between the CE version of Pentaho and other deployments.  Specifically, the index.html change - in CE, without this, it's impossible to load a Saiku file.  But, I feel like you would have fixed this if it was truly broken in all deployments, so it might be a CE only thing.