### PR TITLE
Fixes scrollbar issue on Webkit browsers

### DIFF
--- a/css/saiku/src/styles.css
+++ b/css/saiku/src/styles.css
@@ -876,7 +876,7 @@ span.clear_axis {
     height: 270px;
     width: 430px;
     font-size: 11px;
-    overflow: scroll;
+    overflow: auto;
 }
 .dialog_selections .options:before {
     clear:both;


### PR DESCRIPTION
A small CSS change to fix an issue encountered on Google Chrome on Windows Vista and Windows 7. Also seen on Safari on Mac OS X. 

The scrollbar thumb wasn't being rendered via the overflow: scroll option. This allows the browser's native scrollbar to be shown instead and this works correctly. 
Without the fix, the dialog scroll bars appear like this:
![withoutfix](https://f.cloud.github.com/assets/3593215/947307/7ac8eea0-034f-11e3-92d7-d6b167ca812d.png)

With the fix:
![withfix](https://f.cloud.github.com/assets/3593215/947306/7acf743c-034f-11e3-9a25-2aed15c0963f.png)
