### PR TITLE
Quick fix to hide stats table when clicking table button

### DIFF
--- a/js/saiku/views/Table.js
+++ b/js/saiku/views/Table.js
@@ -372,6 +372,9 @@ var Table = Backbone.View.extend({
             
         }
         this.workspace.processing.hide();
+        if (typeof this.workspace.stats != "undefined") {
+            $(this.workspace.stats.el).hide();
+        }
         this.workspace.adjust();
         // Append the table
         $(this.el).html(contents);


### PR DESCRIPTION
Noticed an issue that when you click the table button with the statistics table viewed then it draws in the same workspace. Hitting the statistics button again hides both tables. 

This fix hides the statistics table when you click the table button. 
