### PR TITLE
Pads hour and minute values in workspace_query_info

### DIFF
--- a/js/saiku/views/Workspace.js
+++ b/js/saiku/views/Workspace.js
@@ -572,7 +572,7 @@ var Workspace = Backbone.View.extend({
         if (chour < 10) chour = "0" + chour;
 
         var cminutes = new Date().getMinutes();
-        if (cminutes < 10) cminutes = "0" + cminute;
+        if (cminutes < 10) cminutes = "0" + cminutes;
         
         var cdate = chour + ":" + cminutes;
         var runtime = args.data.runtime != null ? (args.data.runtime / 1000).toFixed(2) : "";


### PR DESCRIPTION
Pads 0 onto the hour and minutes values for when they're less than 10. So it shows 09:07 rather than 9:7 as currently.
