### PR TITLE
Fix strange behaviour when clicking on hierarchy in DimensionList

### DIFF
--- a/js/saiku/views/DimensionList.js
+++ b/js/saiku/views/DimensionList.js
@@ -24,7 +24,7 @@ var DimensionList = Backbone.View.extend({
     events: {
         'click span': 'select',
         'click a': 'select',
-        'click .parent_dimension ul li a' : 'select_dimension',
+        'click .parent_dimension ul li a.level' : 'select_dimension',
         'click .measure' : 'select_measure'
     },
     


### PR DESCRIPTION
When there are multiple hierarchies per dimension, clicking on a hierarchy causes strange behaviour, because the click handler for levels is called. 
