### PR TITLE
Removed deprecated call

### DIFF
--- a/server.js
+++ b/server.js
@@ -46,7 +46,8 @@ function get_from_proxy(request, response) {
         hostname: backend_host,
         port: backend_port,
         path: request.url,
-        method: request.method
+        method: request.method,
+        headers: request.headers
     };
     
     var proxy_request = http.request(options);


### PR DESCRIPTION
The proxy was broken on recent version of NodeJS (createServer and createClient have been removed).
