### PR TITLE
Fix for statistics plugin wrong values

### DIFF
--- a/js/saiku/plugins/Statistics/plugin.js
+++ b/js/saiku/plugins/Statistics/plugin.js
@@ -104,7 +104,7 @@ var Statistics = Backbone.View.extend({
         }
 
         var group = function(grid, el, cback){
-            var elements = _.filter(_.map(grid, function(it){return it[el]}), function(it){return it});
+            var elements = _.map(grid, function(it){ return it[el]});
             return cback(elements).toFixed(3);
         }
 


### PR DESCRIPTION
For some measures(Calculated Measures cast as string) 0 as minimum was not picked which affect the Standard deviation, and Average as well as minimum.
