### PR TITLE
close about modal on clicking ok

### DIFF
--- a/js/saiku/views/AboutModal.js
+++ b/js/saiku/views/AboutModal.js
@@ -25,7 +25,7 @@ var AboutModal = Modal.extend({
     },
 
     events: {
-    	'click a' : 'dummy'
+    	'click a' : 'close'
     },
 
     dummy: function() { return true;},


### PR DESCRIPTION
I don't know if it was intentional to have 'dummy' as callback function but I think the about modal should close on clicking ok.
