### PR TITLE
Fix for exception in chart export with Chrome

### DIFF
--- a/js/saiku/plugins/CCC_Chart/plugin.js
+++ b/js/saiku/plugins/CCC_Chart/plugin.js
@@ -65,6 +65,7 @@ var Chart = Backbone.View.extend({
         if (svgContent.substr(0,rep.length) != rep) {
             svgContent = svgContent.replace('<svg ', rep);    
         }
+        svgContent = '<!DOCTYPE svg [<!ENTITY nbsp "&#160;">]>' + svgContent;
         
         var form = $('#svgChartPseudoForm');
         form.find('.type').val(type);


### PR DESCRIPTION
With Chrome if dimension value has character with code 160 (nbsp) chart export to image fails with exception.
The reason for this is character escaped by Chrome with &nbsp; entity in embeded svg.

org.apache.batik.transcoder.TranscoderException: null
Enclosed Exception:
The entity "nbsp" was referenced, but not declared.
    at org.apache.batik.transcoder.XMLAbstractTranscoder.transcode(XMLAbstractTranscoder.java:136)
    at org.apache.batik.transcoder.SVGAbstractTranscoder.transcode(SVGAbstractTranscoder.java:156)
    at org.saiku.web.svg.BatikConverter.convert(Converter.java:86)
    at org.saiku.web.rest.resources.ExporterResource.exportChart(ExporterResource.java:166)
    at org.saiku.web.rest.resources.ExporterResource$$FastClassByCGLIB$$e2189a5.invoke(<generated>)
    at net.sf.cglib.proxy.MethodProxy.invoke(MethodProxy.java:191)
    at org.springframework.aop.framework.Cglib2AopProxy$DynamicAdvisedInterceptor.intercept(Cglib2AopProxy.java:617)
    at org.saiku.web.rest.resources.ExporterResource$$EnhancerByCGLIB$$a1f407db.exportChart(<generated>)
    at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
    at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:39)
    at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:25)
    at java.lang.reflect.Method.invoke(Method.java:597)
    at com.sun.jersey.spi.container.JavaMethodInvokerFactory$1.invoke(JavaMethodInvokerFactory.java:60)
    at com.sun.jersey.server.impl.model.method.dispatch.AbstractResourceMethodDispatchProvider$ResponseOutInvoker._dispatch(AbstractResourceMethodDispatchProvider.java:205)
    at com.sun.jersey.server.impl.model.method.dispatch.ResourceJavaMethodDispatcher.dispatch(ResourceJavaMethodDispatcher.java:75)
    at com.sun.jersey.server.impl.uri.rules.HttpMethodRule.accept(HttpMethodRule.java:288)
